### PR TITLE
Product pagination

### DIFF
--- a/src/app/components/product-page/product-page.component.css
+++ b/src/app/components/product-page/product-page.component.css
@@ -41,3 +41,31 @@
   max-width: 300px;
   font-size: 1rem;
 }
+
+.toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+  gap: 1rem;
+  flex-wrap: wrap;
+
+  label {
+    font-size: 0.95rem;
+  }
+
+  select {
+    margin: 0 0.5rem;
+    padding: 0.3rem 0.5rem;
+    font-size: 1rem;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+  }
+
+  .total {
+    font-size: 0.95rem;
+    color: #555;
+  }
+}
+
+

--- a/src/app/components/product-page/product-page.component.html
+++ b/src/app/components/product-page/product-page.component.html
@@ -20,7 +20,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr *ngFor="let product of filteredProducts">
+        <tr *ngFor="let product of pagedProducts">
           <td>
             <img [src]="product.logo" alt="Logo" width="80" height="45" />
           </td>
@@ -29,6 +29,24 @@
           <td>{{ product.date_release }}</td>
           <td>{{ product.date_revision }}</td>
         </tr>
+        <div class="toolbar">
+          <span class="total">
+            Total: {{ filteredProducts.length }} Resultados
+          </span>
+
+          <label>
+            Mostrar
+            <select
+              #pageSizeSelect
+              (change)="onChangePageSize(+pageSizeSelect.value)"
+            >
+              <option [value]="5">5</option>
+              <option [value]="10">10</option>
+              <option [value]="20">20</option>
+            </select>
+            registros
+          </label>
+        </div>
       </tbody>
     </table>
   </ng-container>

--- a/src/app/components/product-page/product-page.component.html
+++ b/src/app/components/product-page/product-page.component.html
@@ -31,7 +31,7 @@
         </tr>
         <div class="toolbar">
           <span class="total">
-            Total: {{ filteredProducts.length }} Resultados
+            Total: {{ filteredProducts.length || "0" }} Resultados
           </span>
 
           <label>

--- a/src/app/components/product-page/product-page.component.ts
+++ b/src/app/components/product-page/product-page.component.ts
@@ -15,6 +15,10 @@ export class ProductPageComponent {
   searchTerm: string = '';
   filteredProducts: Product[] = [];
 
+  minNumberOfProducts: number = 5;
+  currentPage: number = 1;
+  pagedProducts: Product[] = [];
+
   constructor(private productService: ProductService) {}
 
   ngOnInit(): void {
@@ -34,5 +38,17 @@ export class ProductPageComponent {
     this.filteredProducts = this.products.filter((product) =>
       product.name.toLowerCase().includes(this.searchTerm)
     );
+  }
+
+  updatePagedProducts(): void {
+    const startIndex = (this.currentPage - 1) * this.minNumberOfProducts;
+    const endIndex = startIndex + this.minNumberOfProducts;
+    this.pagedProducts = this.filteredProducts.slice(startIndex, endIndex);
+  }
+
+  onChangePageSize(size: number): void {
+    this.minNumberOfProducts = size;
+    this.currentPage = 1;
+    this.updatePagedProducts();
   }
 }


### PR DESCRIPTION
### Context
If we show all the results at the same time in the table, we can make the navigator slow. The objective is to find a way to show a limited number of results in the table.

### Changes
- Add a select to choose how many results we want to show.
- Add a section to show how many results are the table showing.

### Result
Now, the table will only show a limited number of results, and users will be able to choose how many results are shown to prevent the navigator from slowing down.
<img width="857" height="65" alt="image" src="https://github.com/user-attachments/assets/5e794c50-7519-428a-8935-79bd5dd08888" />
